### PR TITLE
replace zero-sum check with delinquent payer check

### DIFF
--- a/request_json_validation.py
+++ b/request_json_validation.py
@@ -1,5 +1,13 @@
 from jsonschema import validate, SchemaError, ValidationError
 
+def error_handling(request, schema):
+    try:
+        validate(instance=request, schema=schema)
+    except ValidationError as error:
+        return error.message
+    except SchemaError as error:
+        return error.message
+
 def add_json_validation(request):
     schema = {
         "type" : "object",
@@ -12,10 +20,7 @@ def add_json_validation(request):
         "additionalProperties": False
     }
 
-    try:
-        validate(instance=request, schema=schema)
-    except ValidationError as error:
-        return error.message
+    return error_handling(request, schema)
 
 
 def spend_json_validation(request):
@@ -28,7 +33,4 @@ def spend_json_validation(request):
         "additionalProperties": False
     }
 
-    try:
-        validate(instance=request, schema=schema)
-    except ValidationError as error:
-        return error.message
+    return error_handling(request, schema)

--- a/request_logic.py
+++ b/request_logic.py
@@ -3,52 +3,39 @@ from flask import jsonify
 
 transactions = []
 
+#sorts transactions by timestamp
+def sort_transactions():
+    sorted_transactions = sorted(transactions, key=lambda d: d['timestamp'])
+    
+    transactions.clear()
+
+    for i in sorted_transactions:
+        transactions.append(i)
+
+
 #calculates existing balances for all payers and trims zero-sum balances
 #accepts a list of transactions
 #returns a dict of balances by payer
 def calculate_balances():
+    sort_transactions()
     point_balances = {}
     for i in transactions:
         if i['payer'] in point_balances.keys():
             point_balances[i['payer']] = point_balances[i['payer']] + i['points']
         else:
             point_balances[i['payer']] = i['points']
-    print('About to enter trim function.')
-    trim_zero_sum_transactions(point_balances)
     return point_balances
-
-#trims zero-sum transactions by payer based on total payer balances
-#accepts a dict of balances by payer (identical to returned value of calculate_balances())
-def trim_zero_sum_transactions(balances):
-    zero_sum_payers = []
-    transactions_to_delete = []
-    counter = 0
-
-    for i in balances:
-        if balances[i] == 0:
-            zero_sum_payers.append(i)
-
-    for i in zero_sum_payers:
-        for t in transactions:
-            if i in t['payer']:
-                transactions_to_delete.append(counter)
-            counter += 1
-        balances.pop(i)
-
-    transactions_to_delete = sorted(transactions_to_delete, reverse=True)
-
-    for i in transactions_to_delete:
-        del transactions[i]
 
 
 #calculates total point balance across all payers
 #accepts a list of transactions
 #returns a point total integer
-def calculate_total_balance(passed_transactions):
+def calculate_total_balance():
     total_balance = 0
-    for i in passed_transactions:
+    for i in transactions:
         total_balance += i['points']
     return total_balance
+
 
 #calculates total balance spent, based on differences in passed balances
 #accepts two dicts of balances by payer (identical to returned value of calculate_balances())
@@ -66,10 +53,11 @@ def calculate_spent_balances(original_balance, new_balance):
     response = jsonify(spent_points_list)
     return response
 
+
 #checks for potential negative values for payer totals
 #accepts a transaction request
 #returns True/False and point total integer for that payer
-def check_for_negative_balance(request):
+def check_for_negative_balance_on_request(request):
     payer_point_balances = calculate_balances()
     if request['payer'] not in payer_point_balances.keys() and request['points'] >= 0:
         return False, 0
@@ -81,28 +69,42 @@ def check_for_negative_balance(request):
         else: return False, payer_point_balances[request['payer']]
 
 
-#spends a requested total of points
-#accepts a list of transactions and a points integer
-#returns a list of transations
-def point_spender(passed_sorted_transactions, points):
+#checks for any payers with a negative point balance
+#returns an amount of points past what they were able to spend integer
+def check_for_delinquent_payer():
+    delinquent_points = 0
+    current_balance = calculate_balances()
+    for i in current_balance:
+        if current_balance[i] < 0:
+            delinquent_points -= current_balance[i]
+            delinquent_payer = i
+            counter_3 = 0
+            for t in transactions:
+                if t['payer'] == delinquent_payer:
+                    transactions[counter_3]['points'] = 0
+                counter_3 += 1
+    return delinquent_points
+
+
+#spends a requested number of points
+#accepts a points integer
+def point_spender(points):
+    sort_transactions()
     counter = 0
     while points > 0:
-        for i in passed_sorted_transactions:
+        for i in transactions:
             if (points - i['points']) > 0:
                 points = points - i['points']
                 i['points'] = 0
                 counter+=1
             elif (points - i['points']) == 0:
                 i['points'] = 0
-                del passed_sorted_transactions[0:counter+1]
-                points = 0
+                points = check_for_delinquent_payer()
                 break
             elif (points - i['points']) < 0:
                 i['points'] = i['points'] - points
-                del passed_sorted_transactions[0:counter]
-                points = 0
+                points = check_for_delinquent_payer()
                 break
-    return passed_sorted_transactions
 
 
 #carries out collective logic required for add endpoint
@@ -114,7 +116,8 @@ def add_points(add_request):
     if json_validation != None:
         return json_validation, 400
 
-    negative_check = check_for_negative_balance(add_request)
+    negative_check = check_for_negative_balance_on_request(add_request)
+
     if negative_check[0] == False:
         transactions.append(add_request)
         return f'Transaction added:\n{transactions[-1]}'
@@ -133,8 +136,7 @@ def spend_points(spend_request):
     
     original_balance = calculate_balances()
     points = spend_request['points']
-    sorted_transactions = sorted(transactions, key=lambda d: d['timestamp'])
-    total_balance = calculate_total_balance(sorted_transactions)
+    total_balance = calculate_total_balance()
     json_validation = rj.spend_json_validation(spend_request)
 
     if points <= 0:
@@ -142,9 +144,6 @@ def spend_points(spend_request):
     if total_balance < points:
         return f'Requested {points} points be spent, but there are only {total_balance} points available. Cannot request to spend more points than are available.', 400
     else:
-        transactions.clear()
-        new_transactions = point_spender(sorted_transactions, points)
-        for i in new_transactions:
-            transactions.append(i)
+        point_spender(points)
         new_balance = calculate_balances()
         return calculate_spent_balances(original_balance, new_balance)


### PR DESCRIPTION
This is mainly to replace the zero-sum logic with delinquent payer check logic. That is, instead of checking for zero-sum payers after each point spend, and trying to write logic to manage that scenario, delinquent payers are instead checked for (payers with a negative point balance after spending a transaction of points).